### PR TITLE
将“等待音乐软件侧传输歌词...”改为“等待歌词...”

### DIFF
--- a/LyricsControl.xaml
+++ b/LyricsControl.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ci="http://classisland.tech/schemas/xaml/core">
     <TextBlock x:Name="LyricsText"
-               Text="等待音乐软件侧传输歌词..."
+               Text="等待歌词..."
                HorizontalAlignment="Center" 
                VerticalAlignment="Center" 
                FontSize="16"/>


### PR DESCRIPTION
在音乐软件没有启动的情况下，放这么长一大串文字实在不好看。
之前也有为此提issue的想法，今天就趁着自己Fork出了一份Hyper-V版本提个PR吧（）